### PR TITLE
fix: restore item amount to header

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -249,7 +249,17 @@ function clearCheck() {
   _recipes.value = copy
 }
 function doOriginal(index: number) {
-  // Reserved for restoring original amount; implement if needed
+  const item = recipe.value?.ingredients?.[index]
+  if (!item) return
+  const amount = parseFloat(item.amount || '0')
+  if (!amount) return
+  const copy = [..._recipes.value]
+  copy[recipeId.value].original = amount
+  copy[recipeId.value].desired = amount
+  _recipes.value = copy
+  setTimeout(() => {
+    document.getElementById('input-desired')?.focus()
+  }, 0)
 }
 function array_move<T>(array: T[], sourceIndex: number, destinationIndex: number): T[] {
   const smallerIndex = Math.min(sourceIndex, destinationIndex)


### PR DESCRIPTION
## Summary
- set recipe original/desired from ingredient when clicking the ruler
- focus desired amount input for quick editing

## Testing
- `npm test` *(fails: Could not find any test files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a0cfdc6ee4832992d72c0db4695a8f