### PR TITLE
fix: support share target from chrome

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,30 +1,30 @@
 {
-    "name":"Kukkingu",
-    "short_name":"Kukkingu",
-    "icons":[
-        {
-            "src":"/android-chrome-192x192.png",
-            "sizes":"192x192",
-            "type":"image/png"
-        },
-        {
-            "src":"/android-chrome-512x512.png",
-            "sizes":"512x512",
-            "type":"image/png"
-        }
-    ],
-    "orientation": "portrait",
-    "theme_color":"#2563eb",
-    "background_color":"#2563eb",
-    "display":"standalone",
-    "share_target": {
-        "action": "/",
-        "method": "GET",
-        "enctype": "application/x-www-form-urlencoded",
-        "params": {
-            "title": "title",
-            "text": "text",
-            "url": "url"
-        }
+  "name": "Kukkingu",
+  "short_name": "Kukkingu",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
     }
+  ],
+  "orientation": "portrait",
+  "theme_color": "#2563eb",
+  "background_color": "#2563eb",
+  "display": "standalone",
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "application/x-www-form-urlencoded",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  }
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -12,6 +12,22 @@ routing.registerRoute(
   new strategies.StaleWhileRevalidate({ cacheName }),
 )
 
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  if (event.request.method === 'POST' && url.pathname === '/share-target') {
+    event.respondWith(
+      (async () => {
+        const formData = await event.request.formData()
+        const title = formData.get('title') || ''
+        const text = formData.get('text') || ''
+        const sharedUrl = formData.get('url') || ''
+        const params = new URLSearchParams({ title, text, url: sharedUrl })
+        return Response.redirect('/?' + params.toString(), 303)
+      })()
+    )
+  }
+})
+
 
 // removes all caches not named <cacheName>
 const invalidateOldCache = async () => {


### PR DESCRIPTION
## Summary
- allow app to be selected as a share target by Chrome
- handle share POSTs in service worker and redirect to app

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a1e8aa21b083298863b10a4818e9bd