### PR TITLE
fix: handle large chatgpt prompts

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -197,6 +197,7 @@ import ModalInput from './ModalInput.vue'
 import { t, currentLocale } from '~src/i18n'
 import { buildAskRecipePrompt } from '~src/services/prompt'
 import { normalizeAmountType } from '~src/services/units'
+import { openChatGPT } from '~src/services/chatgpt'
 
 const route = useRoute()
 const router = useRouter()
@@ -244,7 +245,7 @@ function openAskGpt() {
   showAskGpt.value = true
 }
 
-function confirmAskGpt(question: string) {
+async function confirmAskGpt(question: string) {
   showAskGpt.value = false
   const locale =
     currentLocale.value === 'jp'
@@ -253,7 +254,8 @@ function confirmAskGpt(question: string) {
       ? 'German'
       : 'English'
   const prompt = buildAskRecipePrompt(recipe.value, question, locale)
-  window.open(`https://chatgpt.com/?q=${encodeURIComponent(prompt)}`, '_blank')
+  const copied = await openChatGPT(prompt)
+  if (copied) alert(t('Prompt copied. Paste into ChatGPT.'))
 }
 
 function norm(type: string): string {

--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -143,6 +143,7 @@ import ModalUrlText from './ModalUrlText.vue'
 import { mergeRecipesByExportedAt } from '~src/services/importExport'
 import { chooseExportFile, saveExportFile, loadFromFile } from '~src/services/fileExport'
 import { buildImportRecipePrompt } from '~src/services/prompt'
+import { openChatGPT } from '~src/services/chatgpt'
 
 const router = useRouter()
 const recipes = computed({ get: () => _recipes.value, set: (v) => (_recipes.value = v as any) })
@@ -251,7 +252,7 @@ function openImportUrl() {
   showImportUrlModal.value = true
 }
 
-function confirmImportUrl(payload: { url: string; text: string; fromPicture: boolean }) {
+async function confirmImportUrl(payload: { url: string; text: string; fromPicture: boolean }) {
   importUrl.value = payload.url
   importText.value = payload.text
   importFromPicture.value = payload.fromPicture
@@ -271,8 +272,8 @@ function confirmImportUrl(payload: { url: string; text: string; fromPicture: boo
     showToast(t('Prompt copied. Opening Gemini...'))
     window.open('https://gemini.google.com/', '_blank')
   } else {
-    // Default to ChatGPT with query param
-    window.open(`https://chatgpt.com/?q=${encodeURIComponent(prompt)}`, '_blank')
+    const copied = await openChatGPT(prompt)
+    if (copied) showToast(t('Prompt copied. Opening ChatGPT...'))
   }
 }
 

--- a/src/services/chatgpt.ts
+++ b/src/services/chatgpt.ts
@@ -1,0 +1,36 @@
+const MAX_QUERY_LENGTH = 2000
+
+function legacyCopyToClipboard(text: string) {
+  try {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'absolute'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textarea)
+  } catch (e) {
+    // Ignore copy errors
+  }
+}
+
+export async function openChatGPT(prompt: string): Promise<boolean> {
+  const encoded = encodeURIComponent(prompt)
+  if (encoded.length < MAX_QUERY_LENGTH) {
+    window.open(`https://chatgpt.com/?q=${encoded}`, '_blank')
+    return false
+  }
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(prompt)
+    } else {
+      legacyCopyToClipboard(prompt)
+    }
+  } catch (e) {
+    legacyCopyToClipboard(prompt)
+  }
+  window.open('https://chatgpt.com/', '_blank')
+  return true
+}


### PR DESCRIPTION
## Summary
- avoid 431 errors by copying large prompts to clipboard and opening ChatGPT without query
- reuse helper in Recipe and Storage views

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a23077679c8329a1293cb1eb503f08