### PR TITLE
fix: open Gemini for short YouTube URLs

### DIFF
--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -266,7 +266,7 @@ async function confirmImportUrl(payload: { url: string; text: string; fromPictur
   })
 
   const url = importUrl.value || ''
-  if (url.includes('youtube.com')) {
+  if (url.includes('youtube.com') || url.includes('youtu.be')) {
     // Gemini does not support passing query params; copy prompt to clipboard (legacy exec)
     legacyCopyToClipboard(prompt)
     showToast(t('Prompt copied. Opening Gemini...'))


### PR DESCRIPTION
## Summary
- open Gemini when a `youtu.be` link is imported

## Testing
- `npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a2342439a48329b3ff49026f4f13ca