### PR TITLE
fix: ensure modals stay within viewport

### DIFF
--- a/src/components/ModalConfirm.vue
+++ b/src/components/ModalConfirm.vue
@@ -12,11 +12,11 @@
     >
       <div
         v-if="modelValue"
-        class="fixed w-screen w-full h-screen top-0 left-0 z-50"
+        class="fixed w-screen w-full h-screen top-0 left-0 z-50 overflow-y-auto"
         style="backdrop-filter: blur(1px)"
         @click="clickNo"
       >
-        <div class="w-full h-full px-12 pb-8 flex flex-col justify-end transform">
+        <div class="w-full min-h-full px-12 py-8 flex flex-col transform">
           <div class="w- bg-white p-5 rounded-xl drop-shadow">
             <div class="text-lg text-gray-600 font-bold">
               {{ t('Really delete') }}?<br />

--- a/src/components/ModalInput.vue
+++ b/src/components/ModalInput.vue
@@ -12,11 +12,11 @@
     >
       <div
         v-if="modelValue"
-        class="fixed w-screen w-full h-screen top-0 left-0 z-50"
+        class="fixed w-screen w-full h-screen top-0 left-0 z-50 overflow-y-auto"
         style="backdrop-filter: blur(1px)"
         @click="close"
       >
-        <div class="w-full h-full px-12 pb-8 flex flex-col justify-end transform">
+        <div class="w-full min-h-full px-12 py-8 flex flex-col transform">
           <div class="bg-white p-5 rounded-xl drop-shadow" @click.stop>
             <div class="text-lg text-gray-600 font-bold">{{ title }}</div>
             <div class="my-5">

--- a/src/components/ModalLocale.vue
+++ b/src/components/ModalLocale.vue
@@ -12,11 +12,11 @@
     >
       <div
         v-if="modelValue"
-        class="fixed w-screen h-screen top-0 left-0 z-50"
+        class="fixed w-screen h-screen top-0 left-0 z-50 overflow-y-auto"
         style="backdrop-filter: blur(2px)"
         @click="close"
       >
-        <div class="w-full h-full px-6 pb-8 flex flex-col justify-end">
+        <div class="w-full min-h-full px-6 py-8 flex flex-col">
           <div class="bg-white p-6 rounded-2xl shadow-lg" @click.stop>
             <div class="text-xl text-gray-700 font-bold mb-4">{{ t('Language') }}</div>
 

--- a/src/components/ModalUrlText.vue
+++ b/src/components/ModalUrlText.vue
@@ -12,11 +12,11 @@
     >
       <div
         v-if="modelValue"
-        class="fixed w-screen w-full h-screen top-0 left-0 z-50"
+        class="fixed w-screen w-full h-screen top-0 left-0 z-50 overflow-y-auto"
         style="backdrop-filter: blur(1px)"
         @click="close"
       >
-        <div class="w-full h-full px-12 pb-8 flex flex-col justify-end transform">
+        <div class="w-full min-h-full px-12 py-8 flex flex-col transform">
           <div class="bg-white p-5 rounded-xl drop-shadow" @click.stop>
             <div class="text-lg text-gray-600 font-bold">{{ title }}</div>
             <div class="my-5 space-y-4">


### PR DESCRIPTION
## Summary
- prevent modals from extending above the viewport and allow scrolling when content overflows

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a23934f2d48329a3f6babadab15070