### PR TITLE
fix: blur target amount input on enter

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -86,8 +86,8 @@ const elDesire = ref<any>(null)
 function focusNext() {
   elDesire.value?.focus()
 }
-function blurInput(e: any) {
-  e.detail?.el?.blur?.()
+function blurInput(e: { el: HTMLInputElement | null }) {
+  e.el?.blur()
 }
 function home() {
   router.push('/')


### PR DESCRIPTION
## Summary
- ensure header's target amount input loses focus when pressing Enter

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a23971b14c83299ae4278a27004985