### PR TITLE
fix: add haptic feedback in modals

### DIFF
--- a/src/components/ModalConfirm.vue
+++ b/src/components/ModalConfirm.vue
@@ -45,14 +45,17 @@
 
 <script lang="ts" setup>
 import { t } from '~src/i18n'
+import { vibrate } from '~src/services/vibrate'
 
 defineProps<{ modelValue: boolean; removeName?: string }>()
 const emit = defineEmits<{ (e: 'confirm'): void; (e: 'cancel'): void; (e: 'update:modelValue', v: boolean): void }>()
 
 function clickYes() {
+  vibrate()
   emit('confirm')
 }
 function clickNo() {
+  vibrate()
   emit('cancel')
 }
 </script>

--- a/src/components/ModalInput.vue
+++ b/src/components/ModalInput.vue
@@ -60,6 +60,7 @@
 import { ref, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import SInput from './Input.vue'
 import { t } from '~src/i18n'
+import { vibrate } from '~src/services/vibrate'
 
 const props = withDefaults(
   defineProps<{
@@ -126,9 +127,11 @@ watch(
 )
 
 function confirm() {
+  vibrate()
   emit('confirm', localValue.value)
 }
 function close() {
+  vibrate()
   emit('cancel')
   emit('update:modelValue', false)
 }

--- a/src/components/ModalLocale.vue
+++ b/src/components/ModalLocale.vue
@@ -66,6 +66,7 @@
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
 import { t } from '~src/i18n'
+import { vibrate } from '~src/services/vibrate'
 
 const props = defineProps<{ modelValue: boolean; locale: string }>()
 const emit = defineEmits<{
@@ -92,9 +93,11 @@ watch(
 )
 
 function confirm() {
+  vibrate()
   emit('confirm', localLocale.value)
 }
 function close() {
+  vibrate()
   emit('cancel')
   emit('update:modelValue', false)
 }

--- a/src/components/ModalNotice.vue
+++ b/src/components/ModalNotice.vue
@@ -44,6 +44,7 @@
 <script lang="ts" setup>
 import Icon from './Icon.vue'
 import { t } from '~src/i18n'
+import { vibrate } from '~src/services/vibrate'
 
 const props = withDefaults(
   defineProps<{
@@ -64,10 +65,12 @@ const emit = defineEmits<{
 }>()
 
 function acknowledge() {
+  vibrate()
   emit('ok')
   emit('update:modelValue', false)
 }
 function close() {
+  vibrate()
   emit('update:modelValue', false)
 }
 </script>

--- a/src/components/ModalUrlText.vue
+++ b/src/components/ModalUrlText.vue
@@ -77,6 +77,7 @@ import { ref, watch, nextTick } from 'vue'
 import SInput from './Input.vue'
 import Checkbox from './Checkbox.vue'
 import { t } from '~src/i18n'
+import { vibrate } from '~src/services/vibrate'
 
 const props = withDefaults(
   defineProps<{
@@ -135,6 +136,7 @@ watch(
 )
 
 function confirm() {
+  vibrate()
   emit('confirm', {
     url: (localUrl.value || '').trim(),
     text: (localText.value || '').trim(),
@@ -142,6 +144,7 @@ function confirm() {
   })
 }
 function close() {
+  vibrate()
   emit('cancel')
   emit('update:modelValue', false)
 }

--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -84,7 +84,7 @@
               </Button>
             </div>
           </template>
-          <div class="col-span-12 px-3 pb-3 pt-5 rounded-lg relative bg-gray-900 text-2xl text-white" @click="handleItemClick(index)">
+          <div class="col-span-12 px-3 pb-3 pt-5 rounded-lg relative bg-gray-900 text-2xl text-white select-none" @click="handleItemClick(index)">
             <div class="grid grid-cols-12">
               <div class="col-span-10">
 


### PR DESCRIPTION
## Summary
- vibrate when pressing confirm or cancel in modals
- avoid ingredient text selection in recipe view

## Testing
- `npm test` *(fails: The environment variable CHROME_PATH must be set to executable of a build of Chromium version 54.0 or later.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4b4d6ce088329bd0cdc64e09985a5