### PR TITLE
fix: adjust overview button styling and swipe

### DIFF
--- a/src/components/Storage.vue
+++ b/src/components/Storage.vue
@@ -80,7 +80,7 @@
         :style="transitionName === 'ov' ? staggerStyle(index) : null"
         class="ov-item"
       >
-        <div v-if="item.rename" class="flex items-baseline rounded-xl bg-gray-300 px-2 py-2 my-1">
+        <div v-if="item.rename" class="flex items-baseline rounded-xl bg-gray-400 px-2 py-2 my-1">
           <div class="flex-grow pr-2">
             <SInput
               @enter="() => rename(index)"
@@ -102,11 +102,10 @@
         </div>
         <div
           v-else
-          class="flex items-center rounded-xl bg-gray-300 px-2 py-2 my-1 overflow-x-auto no-scrollbar"
+          class="flex items-center rounded-xl bg-gray-400 px-2 py-2 my-1 overflow-x-auto md:overflow-visible no-scrollbar"
         >
-          <div class="flex items-baseline w-full flex-shrink-0 pr-2">
+          <div class="flex items-baseline w-full flex-shrink-0 pr-2 md:w-auto md:flex-1 md:flex-shrink">
             <Button
-              color="pink"
               @click="open(index)"
               class="flex-grow text-[1.1rem] leading-5 tracking-wider !px-2 !text-left"
             >


### PR DESCRIPTION
## Summary
- darken overview item background and remove pink button styling
- show action buttons on desktop while keeping horizontal swipe on mobile

## Testing
- `npm test` *(fails: Failed to launch the browser process; chromium snap required)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a4b458ff148329a831704d20ab6a3a