### PR TITLE
feat: add camera capture for recipe images

### DIFF
--- a/src/components/ModalManageImage.vue
+++ b/src/components/ModalManageImage.vue
@@ -55,6 +55,14 @@
             class="hidden"
             @change="handleFileSelect"
           />
+          <input
+            ref="cameraInput"
+            type="file"
+            accept="image/*"
+            capture="environment"
+            class="hidden"
+            @change="handleCameraCapture"
+          />
 
           <!-- Paste Area -->
           <div
@@ -69,7 +77,11 @@
           <div class="flex flex-wrap flex-row justify-center gap-2">
             <Button @click="triggerFileInput" color="gray" class="!text-sm">
               <Icon icon="fal fa-plus" class="mr-2" size="1rem" />
-              {{ localRecipe.image ? t('Replace Image') : t('Add Image') }}
+              {{ t('Browse Image') }}
+            </Button>
+            <Button @click="triggerCameraInput" color="gray" class="!text-sm">
+              <Icon icon="fal fa-camera" class="mr-2" size="1rem" />
+              {{ t('Take Photo') }}
             </Button>
             <Button
               v-if="localRecipe.image"
@@ -277,6 +289,7 @@ const showModal = computed({
 
 
 const fileInput = ref<HTMLInputElement | null>(null)
+const cameraInput = ref<HTMLInputElement | null>(null)
 const pasteArea = ref<HTMLDivElement | null>(null)
 const showCropModal = ref(false)
 const showZoomModal = ref(false)
@@ -337,10 +350,13 @@ function triggerFileInput() {
   fileInput.value?.click()
 }
 
-async function handleFileSelect(event: Event) {
-  const target = event.target as HTMLInputElement
-  const file = target.files?.[0]
-  if (file && isValidImageFile(file)) {
+function triggerCameraInput() {
+  cameraInput.value?.click()
+}
+
+async function processSelectedFile(file?: File | null) {
+  if (!file) return
+  if (isValidImageFile(file)) {
     try {
       const base64 = await optimizeImageFile(file)
       // Update the recipe image temporarily for preview
@@ -349,10 +365,22 @@ async function handleFileSelect(event: Event) {
       console.error('Failed to process image file:', error)
       // Could show a notice here
     }
-  } else if (file) {
-    // Could show a notice about invalid file
+  } else {
+    console.warn('Invalid image file selected')
   }
-  // Clear the input
+}
+
+async function handleFileSelect(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  await processSelectedFile(file)
+  if (target) target.value = ''
+}
+
+async function handleCameraCapture(event: Event) {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  await processSelectedFile(file)
   if (target) target.value = ''
 }
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -85,6 +85,8 @@
   "Privacy Policy": "Datenschutzerklärung",
   "Image": "Bild",
   "Paste image here": "Bild hier einfügen",
+  "Browse Image": "Bild auswählen",
+  "Take Photo": "Foto aufnehmen",
   "Error": "Fehler",
   "Failed to process image file": "Bilddatei konnte nicht verarbeitet werden",
   "Invalid file": "Ungültige Datei",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -85,6 +85,8 @@
   "Privacy Policy": "Privacy Policy",
   "Image": "Image",
   "Paste image here": "Paste image here",
+  "Browse Image": "Browse Image",
+  "Take Photo": "Take Photo",
   "Error": "Error",
   "Failed to process image file": "Failed to process image file",
   "Invalid file": "Invalid file",

--- a/src/i18n/jp.json
+++ b/src/i18n/jp.json
@@ -86,6 +86,8 @@
   "Privacy Policy": "プライバシーポリシー",
   "Image": "画像",
   "Paste image here": "ここに画像を貼り付ける",
+  "Browse Image": "画像を選択",
+  "Take Photo": "写真を撮影",
   "Error": "エラー",
   "Failed to process image file": "画像ファイルの処理に失敗しました",
   "Invalid file": "無効なファイル",


### PR DESCRIPTION
## Summary
- add dedicated browse and take photo controls to the recipe image modal and inline editor
- reuse shared helpers to optimise files from the camera before attaching to recipes
- localise new labels for the browse/take photo actions in all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd4de613e483298f65290e4ab37de3