### PR TITLE
fix: align recipe GPT flow with storage import

### DIFF
--- a/src/components/Recipe.vue
+++ b/src/components/Recipe.vue
@@ -396,6 +396,7 @@ import { buildAskRecipePrompt } from '~src/services/prompt'
 import { normalizeAmountType } from '~src/services/units'
 import { isValidImageFile, pasteImageFromClipboard } from '~src/services/indexeddb'
 import { optimizeImageFile } from '~src/services/imageOptimization'
+import { handlePromptNoticeOk } from '~src/services/notice'
 // no auto-opening; we'll copy prompt and show CTA
 
 const route = useRoute()
@@ -853,7 +854,9 @@ function showPromptReady(message: string, aiService: 'chatgpt' | 'gemini' = 'cha
 
 function handleGoToAI() {
   if (promptReadyGotoUrl.value) {
-    window.open(promptReadyGotoUrl.value, '_blank')
+    handlePromptNoticeOk(promptReadyGotoUrl.value, openImportJson)
+  } else {
+    openImportJson()
   }
 }
 


### PR DESCRIPTION
## Summary
- reuse the prompt notice helper in the recipe Ask GPT flow
- open the recipe JSON import modal when navigating to ChatGPT from the Ask GPT dialog

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cdbe533ca88329ac662c1f55752b96